### PR TITLE
outputDir problem and fix

### DIFF
--- a/R/alevinQCReport.R
+++ b/R/alevinQCReport.R
@@ -128,11 +128,8 @@ alevinQCReport <- function(baseDir, sampleId, outputFile, outputDir = "./",
     }
 
     ## ------------------------- output files ------------------------------- ##
-    outputReport <- file.path(outputDir, basename(outputFile))
-    outputRmd <- file.path(
-        outputDir,
-        paste0(tools::file_path_sans_ext(basename(outputFile)), ".Rmd")
-    )
+    outputReport <- basename(outputFile)
+    outputRmd <- paste0(tools::file_path_sans_ext(basename(outputFile)), ".Rmd")
 
     ## Report
     if (file.exists(outputReport)) {
@@ -177,6 +174,7 @@ alevinQCReport <- function(baseDir, sampleId, outputFile, outputDir = "./",
     args$input <- outputRmd
     args$output_format <- outputFormat
     args$output_file <- outputFile
+    args$output_dir <- outputDir
     args$quiet <- !knitrProgress
 
     ## ---------------------------------------------------------------------- ##


### PR DESCRIPTION
#### Problem Encountered: 
For `alevinQCReport` the `outputDir` argument is not working.  If all arguments are kept the same, but `outputDir` is used, things don't work. 

#### Example of problem: 
```r
# A directory with Alevin results
alevin.dir <- "pbmc_data/alevin_output/pbmc_1k_v2_S1_L001"

# Create results directory if it doesn't exist
if (!dir.exists("results")) {
dir.create("results")
}
# This doesn't work
alevinQCReport(alevin.dir,
                            sampleId = basename(alevin.dir), 
                            outputFile = paste0(basename(alevin.file), 
                                                             "_qc_report.html"), 
                            outputFormat = "html_document",
                            outputDir = "results",
                            forceOverwrite = TRUE)
```
When the above is run, this is the output
Note that all these files do actually exist. 
```r
Reading Alevin output files...
Quitting from lines 31-34 (pbmc_1k_v2_S1_L001_qc_report.Rmd) 
Error in checkAlevinInputFiles(baseDir) : 
The following required file(s) are missing:
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/alevin/raw_cb_frequency.txt
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/alevin/filtered_cb_frequency.txt
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/alevin/featureDump.txt
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/alevin/MappedUmi.txt
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/alevin/whitelist.txt
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/alevin/quants_mat_rows.txt
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/alevin/quants_mat_cols.txt
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/alevin/quants_mat.gz
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/aux_info/meta_info.json
pbmc_data/alevin_output/pbmc_1k_v2_S1_L001/cmd_info.json
```

And, if I get rid of the `outputDir` function, while keeping all the other arguments the same, everything works just fine. This chunk below runs just fine. 
```r
# This works
alevinQCReport(alevin.dir,
                            sampleId = basename(alevin.dir), 
                            outputFile = paste0(basename(alevin.file), 
                                                             "_qc_report.html"), 
                            outputFormat = "html_document",
                            forceOverwrite = TRUE)
```
#### Solution: 
To fix this, I added `outputDir `to the arguments to be passed to `do.call(render, args = args)`
Making this change has things work for me, however, you may want to check that this doesn't disrupt anything else. 